### PR TITLE
create coverage.xml report for Codecov inside tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,5 @@ deps =
 commands =
     scrapy10: pip install scrapy>=1.0,<1.1
     scrapy11: pip install scrapy>=1.1,<1.2
-    {posargs:coverage run -m py.test && coverage xml}
+    {posargs:coverage run -m py.test}
+    {posargs:coverage xml}

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ deps =
 commands =
     scrapy10: pip install scrapy>=1.0,<1.1
     scrapy11: pip install scrapy>=1.1,<1.2
-    {posargs:coverage run -m py.test}
+    {posargs:coverage run -m py.test && coverage xml}


### PR DESCRIPTION
> https://github.com/codecov/example-python

I think this will fix the issue. Tox can be a little tricky because of the isolated environment it produces. The goal is to generate the `coverage.xml` file so Codecov can pick it up at the end.