### PR TITLE
fixed formatting of logging command

### DIFF
--- a/src/scrapy_redis/spiders.py
+++ b/src/scrapy_redis/spiders.py
@@ -64,7 +64,7 @@ class RedisMixin(object):
             self.redis_encoding = settings.get('REDIS_ENCODING', defaults.REDIS_ENCODING)
 
         self.logger.info("Reading start URLs from redis key '%(redis_key)s' "
-                         "(batch size: %(redis_batch_size)s, encoding: %(redis_encoding)",
+                         "(batch size: %(redis_batch_size)s, encoding: %(redis_encoding)s",
                          self.__dict__)
 
         self.server = connection.from_settings(crawler.settings)


### PR DESCRIPTION
This avoids this error when running the redis spider:

```shell
--- Logging error ---
Traceback (most recent call last):
      File "/usr/lib/python3.5/logging/__init__.py", line 980, in emit
          msg = self.format(record)
        File "/usr/lib/python3.5/logging/__init__.py", line 830, in
      format
          return fmt.format(record)
        File "/usr/lib/python3.5/logging/__init__.py", line 567, in
      format
          record.message = record.getMessage()
        File "/usr/lib/python3.5/logging/__init__.py", line 330, in
      getMessage
          msg = msg % self.args
      ValueError: incomplete format
```

more traceback:

```shell
Message: "Reading start URLs from redis key '%(redis_key)s' (batch size:
%(redis_batch_size)s, encoding: %(redis_encoding)"
Arguments: {'redis_encoding': 'utf-8', 'redis_batch_size': 16,
    'crawler': <scrapy.crawler.Crawler object at 0x7fdd0528bc50>,
    'redis_key': 'hiplead:start_urls', 'settings':
        <scrapy.settings.Settings object at 0x7fdd00786358>,
    'start_urls': []}
```